### PR TITLE
Fix exception on print string

### DIFF
--- a/src/kernel/arch/x86_64/cpu/cpuid.s
+++ b/src/kernel/arch/x86_64/cpu/cpuid.s
@@ -2,6 +2,7 @@ section .text
 global _cpuid_model
 _cpuid_model:
     [bits 64]
+    push rbx
     mov eax, 0x0
     cpuid
     mov [processor_string], ebx
@@ -9,16 +10,19 @@ _cpuid_model:
     mov [processor_string + 8], ecx
     mov byte[processor_string + 12], 0
     mov rax, processor_string
+    pop rbx
     ret
 
 ;Maybe just return edx in the future
 ;(ignoring ecx for now)
 global _cpuid_feature_apic
 _cpuid_feature_apic:
+    push rbx
     mov rax, 0x1
     cpuid
     and edx, 0x100
     mov eax, edx
+    pop rbx
     ret
    
     


### PR DESCRIPTION
The error was caused by a problem of the cpuid instruction calls in
cpuid.s that was not preserving ebx register (that must be preserved by
the caller).

Closing #15 