### PR TITLE
Fix Memory Initialization issue

### DIFF
--- a/src/include/kernel/framebuffer.h
+++ b/src/include/kernel/framebuffer.h
@@ -10,6 +10,7 @@
 
 void _fb_putchar(unsigned short int symbol, int cx, int cy, uint32_t fg, uint32_t bg);
 void _fb_printStr(char *string, int cx, int cy, uint32_t fg, uint32_t bg);
+void _fb_putPixel(uint32_t color, int x, int y);
 
 void map_framebuffer(struct multiboot_tag_framebuffer *);
 void set_fb_data(struct multiboot_tag_framebuffer *);

--- a/src/include/kernel/mem/bitmap.h
+++ b/src/include/kernel/mem/bitmap.h
@@ -19,7 +19,7 @@
 
 #define ADDRESS_TO_BITMAP_ENTRY(address)(address / PAGE_SIZE_IN_BYTES)
 
-void _initialize_bitmap();
+void _initialize_bitmap(unsigned long addr);
 
 int64_t _bitmap_request_frame();
 void _bitmap_set_bit(uint64_t);

--- a/src/include/kernel/mem/bitmap.h
+++ b/src/include/kernel/mem/bitmap.h
@@ -19,12 +19,12 @@
 
 #define ADDRESS_TO_BITMAP_ENTRY(address)(address / PAGE_SIZE_IN_BYTES)
 
-void _initialize_bitmap(unsigned long addr);
+void _initialize_bitmap(unsigned long addr, uint32_t size);
 
 int64_t _bitmap_request_frame();
 void _bitmap_set_bit(uint64_t);
 void _bitmap_free_bit(uint64_t);
 bool _bitmap_test_bit(uint64_t);
-uint32_t _compute_kernel_entries();
+uint32_t _compute_kernel_entries(uint64_t);
 
 #endif

--- a/src/include/kernel/mem/pmm.h
+++ b/src/include/kernel/mem/pmm.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-void pmm_setup(unsigned long);
+void pmm_setup(unsigned long, uint32_t);
 void *pmm_alloc_frame();
 void pmm_free_frame(void*);
 bool pmm_check_frame_availability();

--- a/src/include/kernel/mem/pmm.h
+++ b/src/include/kernel/mem/pmm.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-void pmm_setup();
+void pmm_setup(unsigned long);
 void *pmm_alloc_frame();
 void pmm_free_frame(void*);
 bool pmm_check_frame_availability();

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -43,6 +43,8 @@ void _init_basic_system(unsigned long addr){
     tagmmap = (struct multiboot_tag_mmap *) (multiboot_mmap_data + _HIGHER_HALF_KERNEL_MEM_START);
     tagfb   = (struct multiboot_tag_framebuffer *) (multiboot_framebuffer_data + _HIGHER_HALF_KERNEL_MEM_START);
     //Print basic mem Info data
+    _printStringAndNumber("MB2 ADDRESS: 0x", addr + _HIGHER_HALF_KERNEL_MEM_START + 8);
+    _printStringAndNumber("---framebuffer-address: 0x", tagfb->common.framebuffer_addr);
     _printStringAndNumber("Found basic mem Mem info type: ", tagmem->type);
     _printStringAndNumber("Memory lower (in kb): ", tagmem->mem_lower);
     _printStringAndNumber("Memory upper (in kb): ", tagmem->mem_upper); 
@@ -52,8 +54,10 @@ void _init_basic_system(unsigned long addr){
     _printStringAndNumber("---Entrysize: ", tagmmap->entry_size);
     _printStringAndNumber("---EntryVersion: ", tagmmap->entry_version);
     _printStringAndNumber("---Struct size: ", sizeof(struct multiboot_tag_mmap));
+    _printStringAndNumber("---framebuffer-type: ", tagfb->common.framebuffer_type);
     _mmap_parse(tagmmap);
-    pmm_setup();
+    _printStringAndNumber("---framebuffer-address: ", tagfb->common.framebuffer_addr);
+    pmm_setup(addr);
 
     //Print framebuffer info
     _printStringAndNumber("Found multiboot framebuffer: ", tagmem->type); 
@@ -63,6 +67,7 @@ void _init_basic_system(unsigned long addr){
     _printStringAndNumber("---framebuffer-address: ", tagfb->common.framebuffer_addr);
     _printStringAndNumber("---framebuffer-bpp: ", tagfb->common.framebuffer_bpp);
     _printStringAndNumber("---framebuffer-pitch: ", tagfb->common.framebuffer_pitch);
+    _printStringAndNumber("---Address: 0x", tagfb + _HIGHER_HALF_KERNEL_MEM_START);
     set_fb_data(tagfb);
     map_framebuffer(tagfb);
     _printStringAndNumber("---Total framebuffer size is:  ", FRAMEBUFFER_MEMORY_SIZE);
@@ -95,6 +100,7 @@ void _init_basic_system(unsigned long addr){
         switch(tag->type){
            case MULTIBOOT_TAG_TYPE_ELF_SECTIONS:
                 _printStr("Found elf sections");
+                _printStringAndNumber("--Size: 0x", tag->size);
                 _printNewLine();
                 break;
             default:
@@ -187,6 +193,8 @@ void kernel_start(unsigned long addr, unsigned long magic){
     *test_addr = 12l;
     _printStringAndNumber("Should not print ", *test_addr);*/
     initialize_kheap();
+    char test_str[8] = "hello";
+    printf("test_str: %s", test_str);
     asm("hlt");
 }
 

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -38,13 +38,12 @@ struct multiboot_tag *tagacpi = NULL;
 
 void _init_basic_system(unsigned long addr){
     struct multiboot_tag* tag;
+    uint32_t mbi_size = *(uint32_t *) addr;
     //These data structure are initialized durinig the boot process.
     tagmem  = (struct multiboot_tag_basic_meminfo *)(multiboot_basic_meminfo + _HIGHER_HALF_KERNEL_MEM_START);
     tagmmap = (struct multiboot_tag_mmap *) (multiboot_mmap_data + _HIGHER_HALF_KERNEL_MEM_START);
     tagfb   = (struct multiboot_tag_framebuffer *) (multiboot_framebuffer_data + _HIGHER_HALF_KERNEL_MEM_START);
     //Print basic mem Info data
-    _printStringAndNumber("MB2 ADDRESS: 0x", addr + _HIGHER_HALF_KERNEL_MEM_START + 8);
-    _printStringAndNumber("---framebuffer-address: 0x", tagfb->common.framebuffer_addr);
     _printStringAndNumber("Found basic mem Mem info type: ", tagmem->type);
     _printStringAndNumber("Memory lower (in kb): ", tagmem->mem_lower);
     _printStringAndNumber("Memory upper (in kb): ", tagmem->mem_upper); 
@@ -57,7 +56,7 @@ void _init_basic_system(unsigned long addr){
     _printStringAndNumber("---framebuffer-type: ", tagfb->common.framebuffer_type);
     _mmap_parse(tagmmap);
     _printStringAndNumber("---framebuffer-address: ", tagfb->common.framebuffer_addr);
-    pmm_setup(addr);
+    pmm_setup(addr, mbi_size);
 
     //Print framebuffer info
     _printStringAndNumber("Found multiboot framebuffer: ", tagmem->type); 
@@ -79,7 +78,7 @@ void _init_basic_system(unsigned long addr){
         _printStringAndNumber("Found acpi RSDP address: ", (unsigned long) &tagold_acpi);
         RSDPDescriptor *descriptor = (RSDPDescriptor *)(tagacpi+1);
         _printStringAndNumber("Address: ", (unsigned long) &descriptor);
-        _printStringAndNumber("Descriptor revision: ", descriptor->Revision);
+//        _printStringAndNumber("Descriptor revision: ", descriptor->Revision);
         _printStr("Descriptor revision: ");
         _printStr(descriptor->Signature);
         _printNewLine();

--- a/src/kernel/mem/bitmap.c
+++ b/src/kernel/mem/bitmap.c
@@ -16,10 +16,15 @@ uint32_t bitmap_size = 0;
 uint32_t used_frames; 
 
 
-void _initialize_bitmap(){
+void _initialize_bitmap(unsigned long addr){
+    uint32_t mbi_size = *(uint32_t *) addr;
+    _printStringAndNumber("Size of mbi struct: ", mbi_size);
+
     uint32_t memory_size_in_bytes = (tagmem->mem_upper + 1024) * 1024;
     bitmap_size = memory_size_in_bytes / PAGE_SIZE_IN_BYTES;
     used_frames = 0;
+    _printStringAndNumber("KERNEL_END: 0x", &_kernel_end);
+    _printStringAndNumber("KERNEL_END: 0x", &_kernel_physical_end);
     number_of_entries = bitmap_size / 64;
     for (uint32_t i=0; i<number_of_entries; i++){
         memory_map[i] = 0x0;

--- a/src/kernel/mem/bitmap.c
+++ b/src/kernel/mem/bitmap.c
@@ -16,21 +16,20 @@ uint32_t bitmap_size = 0;
 uint32_t used_frames; 
 
 
-void _initialize_bitmap(unsigned long addr){
-    uint32_t mbi_size = *(uint32_t *) addr;
-    _printStringAndNumber("Size of mbi struct: ", mbi_size);
-
+void _initialize_bitmap(unsigned long addr, uint32_t size){
+    memory_map = (uint64_t*) (addr + size);
+    _printStringAndNumber("Size of mbi struct: ", size);
+    _printStringAndNumber("End of reserved area: ", addr+size);
     uint32_t memory_size_in_bytes = (tagmem->mem_upper + 1024) * 1024;
     bitmap_size = memory_size_in_bytes / PAGE_SIZE_IN_BYTES;
     used_frames = 0;
-    _printStringAndNumber("KERNEL_END: 0x", &_kernel_end);
-    _printStringAndNumber("KERNEL_END: 0x", &_kernel_physical_end);
     number_of_entries = bitmap_size / 64;
     for (uint32_t i=0; i<number_of_entries; i++){
         memory_map[i] = 0x0;
     }
+    printf("Here\n");
     
-    uint32_t kernel_entries = _compute_kernel_entries();
+    uint32_t kernel_entries = _compute_kernel_entries(addr + size);
     uint32_t number_of_bitmap_rows = kernel_entries/64;
     uint32_t j=0;
     for (j=0; j < number_of_bitmap_rows; j++){
@@ -49,9 +48,10 @@ void _initialize_bitmap(unsigned long addr){
 }
 
 #ifndef _TEST_
-uint32_t _compute_kernel_entries(){
-    uint32_t kernel_entries = ((uint64_t)&_kernel_physical_end) / PAGE_SIZE_IN_BYTES;
-    uint32_t kernel_mod_entries = ((uint32_t)(&_kernel_physical_end)) % PAGE_SIZE_IN_BYTES;
+uint32_t _compute_kernel_entries(uint64_t end_of_kernel_area){
+    uint32_t kernel_entries = ((uint64_t)end_of_kernel_area) / PAGE_SIZE_IN_BYTES;
+    uint32_t kernel_mod_entries = ((uint32_t)(end_of_kernel_area)) % PAGE_SIZE_IN_BYTES;
+    _printStringAndNumber("number of entries: ", kernel_entries);
     if (  kernel_mod_entries != 0){
         return kernel_entries + 2;
     } 

--- a/src/kernel/mem/mmap.c
+++ b/src/kernel/mem/mmap.c
@@ -35,6 +35,7 @@ void _mmap_parse(struct multiboot_tag_mmap *mmap_root){
         _printStr((char *) mmap_types[mmap_entries[i].type]);
         _printNewLine();
         _printStringAndNumber("---zero:: ", mmap_entries[i].zero);
+        _printStr("END OF MMAP ITEM\n");
         total_entries++;
         i++;
     }

--- a/src/kernel/mem/pmm.c
+++ b/src/kernel/mem/pmm.c
@@ -12,8 +12,8 @@ extern uint32_t bitmap_size;
 extern multiboot_memory_map_t *mmap_entries;
 extern uint8_t count_physical_reserved;
 
-void pmm_setup(unsigned long addr){
-    _initialize_bitmap(addr);
+void pmm_setup(unsigned long addr, uint32_t size){
+    _initialize_bitmap(addr, size);
     //_mmap_setup();
 }
 

--- a/src/kernel/mem/pmm.c
+++ b/src/kernel/mem/pmm.c
@@ -12,8 +12,8 @@ extern uint32_t bitmap_size;
 extern multiboot_memory_map_t *mmap_entries;
 extern uint8_t count_physical_reserved;
 
-void pmm_setup(){
-    _initialize_bitmap();
+void pmm_setup(unsigned long addr){
+    _initialize_bitmap(addr);
     //_mmap_setup();
 }
 

--- a/tests/include/test_common.h
+++ b/tests/include/test_common.h
@@ -7,5 +7,5 @@ void _printStringAndNumber(char *, unsigned long);
 void _printStr(char *);
 void _printNewLine();
 
-uint32_t _compute_kernel_entries();
+uint32_t _compute_kernel_entries(uint64_t);
 #endif

--- a/tests/test_common.c
+++ b/tests/test_common.c
@@ -14,7 +14,7 @@ void _printNewLine(){
     printf("\n");
 }
 
-uint32_t _compute_kernel_entries(){
+uint32_t _compute_kernel_entries(uint64_t end_of_kernel_area){
     uint32_t kernel_entries = 0x1190AC / PAGE_SIZE_IN_BYTES;
     uint32_t kernel_mod_entries = 0x1190AC % PAGE_SIZE_IN_BYTES;
     printf("kernel_entries: 0x%X\n", kernel_entries);

--- a/tests/test_mem.c
+++ b/tests/test_mem.c
@@ -25,7 +25,7 @@ extern uint32_t mmap_number_of_entries;
 extern multiboot_memory_map_t *mmap_entries;
 
 int main(){
-    uint32_t bitmap_entries = _compute_kernel_entries();
+    uint32_t bitmap_entries = _compute_kernel_entries(_kernel_end);
     memory_map = (uint64_t *) malloc(20 * sizeof(uint64_t)); 
     tagmem = (struct multiboot_tag_basic_meminfo *) malloc(sizeof(struct multiboot_tag_basic_meminfo));
     tagmem->mem_lower = 0x27F;
@@ -64,7 +64,7 @@ int main(){
     mmap_root->entry_size = 0x18;
     mmap_root->entry_version = 0;
     _mmap_parse(mmap_root);
-    pmm_setup();
+    pmm_setup((unsigned long) memory_map, 20 * sizeof(uint64_t));
 
     _mmap_setup();
     printf("Testing physical memory manager\n");
@@ -77,6 +77,7 @@ void test_pmm(){
     printf("--- Bitmap ---");
     printf("Used frames: 0x%X\n", used_frames);
     printf("--Testing used_frames value\n");
+    printf("Used frames: %x\n", used_frames);
     assert(used_frames==0x2);
     printf("--Testing memory_map initial value\n");
     printf("memory_map[0] = %X\n", memory_map[0]);


### PR DESCRIPTION
The issue was related to the address of memory map, that was not taking into account the multiboot information structure, that is placed usually after the kernel, this new code now place the memory_map variable right after the multiboot structure.