### PR TITLE
Bitmap base address uses memory map.

### DIFF
--- a/src/include/kernel/mem/bitmap.h
+++ b/src/include/kernel/mem/bitmap.h
@@ -20,6 +20,7 @@
 #define ADDRESS_TO_BITMAP_ENTRY(address)(address / PAGE_SIZE_IN_BYTES)
 
 void _initialize_bitmap(unsigned long);
+void _bitmap_get_region(uint64_t* base_address, size_t* length_in_bytes);
 
 int64_t _bitmap_request_frame();
 void _bitmap_set_bit(uint64_t);

--- a/src/include/kernel/mem/bitmap.h
+++ b/src/include/kernel/mem/bitmap.h
@@ -19,7 +19,7 @@
 
 #define ADDRESS_TO_BITMAP_ENTRY(address)(address / PAGE_SIZE_IN_BYTES)
 
-void _initialize_bitmap(unsigned long addr, uint32_t size);
+void _initialize_bitmap(unsigned long);
 
 int64_t _bitmap_request_frame();
 void _bitmap_set_bit(uint64_t);

--- a/src/include/kernel/mem/mmap.h
+++ b/src/include/kernel/mem/mmap.h
@@ -3,9 +3,18 @@
 
 #include <multiboot.h>
 #include <stdint.h>
+#include <stddef.h>
+
+#define _MMAP_DEFECTIVE 5
+#define _MMAP_NVS 4
+#define _MMAP_RECLAIMABLE 3
+#define _MMAP_RESERVED 2
+#define _MMAP_AVAILABLE 1
+#define _MMAP_INVALID 0
 
 extern const char *mmap_types[];
 
 void _mmap_parse(struct multiboot_tag_mmap*);
 void _mmap_setup();
+void* _mmap_determine_bitmap_region(uint64_t lower_limit, size_t size);
 #endif

--- a/src/kernel/mem/bitmap.c
+++ b/src/kernel/mem/bitmap.c
@@ -22,7 +22,11 @@ void _initialize_bitmap(unsigned long end_of_reserved_area){
     bitmap_size = memory_size_in_bytes / PAGE_SIZE_IN_BYTES;
     used_frames = 0;
     number_of_entries = bitmap_size / 64;
+#ifdef _TEST_
+    memory_map = malloc(bitmap_size);
+#else
     memory_map = _mmap_determine_bitmap_region(0, bitmap_size);
+#endif
     for (uint32_t i=0; i<number_of_entries; i++){
         memory_map[i] = 0x0;
     }

--- a/src/kernel/mem/bitmap.c
+++ b/src/kernel/mem/bitmap.c
@@ -2,6 +2,7 @@
 #include <pmm.h>
 #include <multiboot.h>
 #include <stddef.h>
+#include <mmap.h>
 #ifndef _TEST_
 #include <video.h>
 #include <main.h>
@@ -16,20 +17,18 @@ uint32_t bitmap_size = 0;
 uint32_t used_frames; 
 
 
-void _initialize_bitmap(unsigned long addr, uint32_t size){
-    memory_map = (uint64_t*) (addr + size);
-    _printStringAndNumber("Size of mbi struct: ", size);
-    _printStringAndNumber("End of reserved area: ", addr+size);
+void _initialize_bitmap(unsigned long end_of_reserved_area){
     uint32_t memory_size_in_bytes = (tagmem->mem_upper + 1024) * 1024;
     bitmap_size = memory_size_in_bytes / PAGE_SIZE_IN_BYTES;
     used_frames = 0;
     number_of_entries = bitmap_size / 64;
+    memory_map = _mmap_determine_bitmap_region(0, bitmap_size);
     for (uint32_t i=0; i<number_of_entries; i++){
         memory_map[i] = 0x0;
     }
     printf("Here\n");
     
-    uint32_t kernel_entries = _compute_kernel_entries(addr + size);
+    uint32_t kernel_entries = _compute_kernel_entries(end_of_reserved_area);
     uint32_t number_of_bitmap_rows = kernel_entries/64;
     uint32_t j=0;
     for (j=0; j < number_of_bitmap_rows; j++){

--- a/src/kernel/mem/bitmap.c
+++ b/src/kernel/mem/bitmap.c
@@ -23,9 +23,9 @@ void _initialize_bitmap(unsigned long end_of_reserved_area){
     used_frames = 0;
     number_of_entries = bitmap_size / 64;
 #ifdef _TEST_
-    memory_map = malloc(bitmap_size);
+    memory_map = malloc(bitmap_size / 8 + 1);
 #else
-    memory_map = _mmap_determine_bitmap_region(0, bitmap_size);
+    memory_map = _mmap_determine_bitmap_region(0, bitmap_size / 8 + 1);
 #endif
     for (uint32_t i=0; i<number_of_entries; i++){
         memory_map[i] = 0x0;
@@ -48,6 +48,12 @@ void _initialize_bitmap(unsigned long end_of_reserved_area){
     _printStringAndNumber("Number of items: ", number_of_entries);
     //_bitmap_request_frame();
     //pmm_alloc_frame();
+}
+
+void _bitmap_get_region(uint64_t* base_address, size_t* length_in_bytes)
+{
+    *base_address = (uint64_t)memory_map;
+    *length_in_bytes = bitmap_size / 8;
 }
 
 #ifndef _TEST_

--- a/src/kernel/mem/mmap.c
+++ b/src/kernel/mem/mmap.c
@@ -60,3 +60,25 @@ void _mmap_setup(){
         }
     }
 }
+
+void* _mmap_determine_bitmap_region(uint64_t lower_limit, size_t size){
+    //NOTE: lower_limit can be used to place the bitmap after the kernel, or after anything if need be. 
+
+    for (size_t i = 0; i < mmap_number_of_entries; i++){
+        multiboot_memory_map_t* current_entry = &mmap_entries[i];
+
+        if (current_entry->type != _MMAP_AVAILABLE)
+            continue;
+        if (current_entry->addr < lower_limit)
+            continue;
+
+        if (current_entry->len >= size){
+            _printStringAndNumber("Found space for bitmap at address: ", current_entry->addr);
+            return (void*)current_entry->addr;
+        }
+    }
+
+    //BOOM! D:
+    _printStr("Could not find a space big enough to hold the pmm bitmap!");
+    return NULL;
+}

--- a/src/kernel/mem/pmm.c
+++ b/src/kernel/mem/pmm.c
@@ -14,6 +14,15 @@ extern uint8_t count_physical_reserved;
 
 void pmm_setup(unsigned long addr, uint32_t size){
     _initialize_bitmap(addr + size);
+    uint64_t bitmap_start_addr;
+    size_t bitmap_size;
+    _bitmap_get_region(&bitmap_start_addr, &bitmap_size);
+#ifndef _TEST_
+    //we cant reserve the bitmap in testing scenarios, as malloc() can return any address, usually leading to a super high index when we try to reserve it.
+    //this usually results in a seg fault as we try to access entries in the bitmap waaaay too large.
+    //we could probably get around this hack by asking the host os to map the bitmap as it's expected address via it's vmm.
+    pmm_reserve_area(bitmap_start_addr, bitmap_size);
+#endif
     //_mmap_setup();
 }
 

--- a/src/kernel/mem/pmm.c
+++ b/src/kernel/mem/pmm.c
@@ -13,7 +13,7 @@ extern multiboot_memory_map_t *mmap_entries;
 extern uint8_t count_physical_reserved;
 
 void pmm_setup(unsigned long addr, uint32_t size){
-    _initialize_bitmap(addr, size);
+    _initialize_bitmap(addr + size);
     //_mmap_setup();
 }
 


### PR DESCRIPTION
My version of using the memory map to find a place to put the bitmap!
Main difference is this _mmap_determine_bitmap_region(), which will search the memory map
until it finds space. This makes no assumptions about where free memory is.
This should work with any amount of ram too.
The only limitation is that it it requires a single free region to be large enough for the bitmap.