### PR TITLE
Implemented X2APIC basic functionality

### DIFF
--- a/src/include/kernel/mem/util.h
+++ b/src/include/kernel/mem/util.h
@@ -1,0 +1,19 @@
+#ifndef _UTIL_H
+#define _UTIL_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define READMEM32(addr) \
+(*(volatile uint32_t*)((uintptr_t)addr))
+
+#define READMEM64(addr) \
+(*(volatile uint64_t*)((uintptr_t)addr))
+
+#define WRITEMEM32(addr, u32) \
+(*(volatile uint32_t*)((uintptr_t)addr)) = u32
+
+#define WRITEMEM64(addr, u64) \
+(*(volatile uint64_t*)((uintptr_t)addr)) = u64
+
+#endif

--- a/src/include/kernel/x86_64/lapic.h
+++ b/src/include/kernel/x86_64/lapic.h
@@ -49,7 +49,6 @@ void init_local_vector_table();
 
 void start_apic_timer(uint16_t, bool);
 void write_apic_register(uint32_t, uint32_t);
-void write_apic_icr_register(uint64_t);
 
 uint32_t read_apic_register(uint32_t);
 

--- a/src/include/kernel/x86_64/lapic.h
+++ b/src/include/kernel/x86_64/lapic.h
@@ -35,7 +35,7 @@
 #define APIC_SPURIOUS_VECTOR_REGISTER_OFFSET 0xF0
 #define APIC_SPURIOUS_INTERRUPT_IDT_ENTRY 0xFF
 #define APIC_SOFTWARE_ENABLE (1 << 8)
-
+#define APIC_ID_REGISTER_OFFSET 0x20
 
 
 
@@ -49,8 +49,12 @@ void init_local_vector_table();
 
 void start_apic_timer(uint16_t, bool);
 void write_apic_register(uint32_t, uint32_t);
+void write_apic_icr_register(uint64_t);
 
 uint32_t read_apic_register(uint32_t);
+
+uint32_t lapic_id();
+bool lapic_is_x2();
 
 void disable_pic();
 

--- a/src/kernel/arch/x86_64/cpu/lapic.c
+++ b/src/kernel/arch/x86_64/cpu/lapic.c
@@ -32,7 +32,7 @@ void init_apic() {
     (void)ignored;
     
     if (x2ApicLeaf & (1 << 21)) {
-        printf("X2APIC available!");
+        printf("X2APIC available!\n");
         apicInX2Mode = true;
 
         //no need to map mmio registers as we'll be accessing apic via MSRs
@@ -41,14 +41,14 @@ void init_apic() {
         wrmsr(IA32_APIC_BASE, msr_output);
     }
     else if (xApicLeaf & (1 << 9)) {
-        printf("APIC available!");
+        printf("APIC available!\n");
         apicInX2Mode = false;
 
         //registers are accessed via mmio, make sure they're identity mapped
         map_phys_to_virt_addr(apic_base_address, apic_base_address, 0);
     }
     else {
-        printf("ERROR: No local APIC is supported by this cpu!");
+        printf("ERROR: No local APIC is supported by this cpu!\n");
         return; //not good.
     }
 
@@ -57,7 +57,7 @@ void init_apic() {
     printf("Apic enabled: %x - Apic BSP bit: %x\n", 1&(msr_output >> APIC_GLOBAL_ENABLE_BIT), 1&(msr_output >> APIC_BSP_BIT));
     
     if(!(1&(msr_output >> APIC_GLOBAL_ENABLE_BIT))) {
-        printf("Apic disabled globally");
+        printf("Apic disabled globally\n");
         return;
     }
     
@@ -67,7 +67,7 @@ void init_apic() {
     if(apic_base_address < memory_size_in_bytes) {
         //I think that ideally it should be relocated above the physical memory (that should be possible)
         //but for now i'll mark that location as used
-        printf("Apic base address in physical memory area");
+        printf("Apic base address in physical memory area\n");
         _bitmap_set_bit(ADDRESS_TO_BITMAP_ENTRY(apic_base_address));
     }
     uint32_t version_register = read_apic_register(APIC_VERSION_REGISTER_OFFSET);

--- a/src/kernel/arch/x86_64/cpu/lapic.c
+++ b/src/kernel/arch/x86_64/cpu/lapic.c
@@ -14,13 +14,13 @@ extern uint32_t memory_size_in_bytes;
 uint32_t apic_base_address;
 bool apicInX2Mode;
 
-void init_apic(){
+void init_apic() {
 
     uint64_t msr_output = rdmsr(IA32_APIC_BASE);
     printf("APIC MSR Return value: 0x%X\n", msr_output);
     printf("APIC MSR Base Address: 0x%X\n", (msr_output&APIC_BASE_ADDRESS_MASK));
     apic_base_address = (msr_output&APIC_BASE_ADDRESS_MASK);
-    if(apic_base_address == NULL){
+    if(apic_base_address == NULL) {
         printf("ERROR: cannot determine apic base address\n");
     }
 
@@ -56,7 +56,7 @@ void init_apic(){
     uint32_t spurious_interrupt_register = read_apic_register(APIC_SPURIOUS_VECTOR_REGISTER_OFFSET);
     printf("Apic enabled: %x - Apic BSP bit: %x\n", 1&(msr_output >> APIC_GLOBAL_ENABLE_BIT), 1&(msr_output >> APIC_BSP_BIT));
     
-    if(!(1&(msr_output >> APIC_GLOBAL_ENABLE_BIT))){
+    if(!(1&(msr_output >> APIC_GLOBAL_ENABLE_BIT))) {
         printf("Apic disabled globally");
         return;
     }
@@ -64,7 +64,7 @@ void init_apic(){
     //Enabling apic
     write_apic_register(APIC_SPURIOUS_VECTOR_REGISTER_OFFSET, APIC_SOFTWARE_ENABLE | APIC_SPURIOUS_INTERRUPT);
     
-    if(apic_base_address < memory_size_in_bytes){
+    if(apic_base_address < memory_size_in_bytes) {
         //I think that ideally it should be relocated above the physical memory (that should be possible)
         //but for now i'll mark that location as used
         printf("Apic base address in physical memory area");
@@ -76,7 +76,7 @@ void init_apic(){
     disable_pic();
 }
 
-void disable_pic(){
+void disable_pic() {
     outportb(PIC_COMMAND_MASTER, ICW_1);
     outportb(PIC_COMMAND_SLAVE, ICW_1);
     outportb(PIC_DATA_MASTER, ICW_2_M);
@@ -89,14 +89,14 @@ void disable_pic(){
     outportb(PIC_DATA_SLAVE, 0xFF);
 }
 
-uint32_t read_apic_register(uint32_t register_offset){
+uint32_t read_apic_register(uint32_t register_offset) {
     if (apicInX2Mode)
         return (uint32_t)rdmsr((register_offset >> 4) + 0x800);
     else
         return READMEM32(apic_base_address + register_offset);
 }
 
-void write_apic_register(uint32_t register_offset, uint32_t value){
+void write_apic_register(uint32_t register_offset, uint32_t value) {
     if (apicInX2Mode)
         wrmsr((register_offset >> 4) + 0x800, value);
     else

--- a/src/kernel/arch/x86_64/cpu/lapic.c
+++ b/src/kernel/arch/x86_64/cpu/lapic.c
@@ -6,15 +6,16 @@
 #include <idt.h>
 #include <pic8259.h>
 #include <stdio.h>
+#include <util.h>
+#include <cpuid.h>
+//cpuid is non-standard header, but is supported by both gcc/clang.
 
 extern uint32_t memory_size_in_bytes;
 uint32_t apic_base_address;
+bool apicInX2Mode;
 
 void init_apic(){
-    uint32_t apic_supported = _cpuid_feature_apic();
-    if (apic_supported == 0x100){
-        printf("Apic supported\n");
-    }
+
     uint64_t msr_output = rdmsr(IA32_APIC_BASE);
     printf("APIC MSR Return value: 0x%X\n", msr_output);
     printf("APIC MSR Base Address: 0x%X\n", (msr_output&APIC_BASE_ADDRESS_MASK));
@@ -22,8 +23,37 @@ void init_apic(){
     if(apic_base_address == NULL){
         printf("ERROR: cannot determine apic base address\n");
     }
-    map_phys_to_virt_addr(apic_base_address, apic_base_address, 0);
-    uint32_t *spurious_interrupt_register = (uint64_t *) (apic_base_address + APIC_SPURIOUS_VECTOR_REGISTER_OFFSET);
+
+    //determine if x2apic is available, if so, enable it. It's cpuid leaf 1, ecx bit 21.
+    uint32_t ignored;
+    uint32_t xApicLeaf = 0;
+    uint32_t x2ApicLeaf = 0;
+    __get_cpuid(1, &ignored, &ignored, &x2ApicLeaf, &xApicLeaf);
+    (void)ignored;
+    
+    if (x2ApicLeaf & (1 << 21)) {
+        printf("X2APIC available!");
+        apicInX2Mode = true;
+
+        //no need to map mmio registers as we'll be accessing apic via MSRs
+        //we just set bit 10 of the apic base msr, and we're good to go!
+        msr_output |= (1 << 10);
+        wrmsr(IA32_APIC_BASE, msr_output);
+    }
+    else if (xApicLeaf & (1 << 9)) {
+        printf("APIC available!");
+        apicInX2Mode = false;
+
+        //registers are accessed via mmio, make sure they're identity mapped
+        map_phys_to_virt_addr(apic_base_address, apic_base_address, 0);
+    }
+    else {
+        printf("ERROR: No local APIC is supported by this cpu!");
+        return; //not good.
+    }
+
+
+    uint32_t spurious_interrupt_register = read_apic_register(APIC_SPURIOUS_VECTOR_REGISTER_OFFSET);
     printf("Apic enabled: %x - Apic BSP bit: %x\n", 1&(msr_output >> APIC_GLOBAL_ENABLE_BIT), 1&(msr_output >> APIC_BSP_BIT));
     
     if(!(1&(msr_output >> APIC_GLOBAL_ENABLE_BIT))){
@@ -40,9 +70,9 @@ void init_apic(){
         printf("Apic base address in physical memory area");
         _bitmap_set_bit(ADDRESS_TO_BITMAP_ENTRY(apic_base_address));
     }
-    uint32_t version_register = *(uint32_t *) (apic_base_address + APIC_VERSION_REGISTER_OFFSET);
+    uint32_t version_register = read_apic_register(APIC_VERSION_REGISTER_OFFSET);
     printf("Version register value: 0x%x\n", version_register);
-    printf("Spurious vector value: 0x%x\n", *spurious_interrupt_register);
+    printf("Spurious vector value: 0x%x\n", spurious_interrupt_register);
     disable_pic();
 }
 
@@ -60,13 +90,26 @@ void disable_pic(){
 }
 
 uint32_t read_apic_register(uint32_t register_offset){
-    uint32_t *reg_address = (uint32_t *) (apic_base_address + register_offset);
-    return *reg_address;
+    if (apicInX2Mode)
+        return (uint32_t)rdmsr((register_offset >> 4) + 0x800);
+    else
+        return READMEM32(apic_base_address + register_offset);
 }
 
 void write_apic_register(uint32_t register_offset, uint32_t value){
-    uint32_t *reg_address = (uint32_t *) (apic_base_address + register_offset);
-    *reg_address = value;
+    if (apicInX2Mode)
+        wrmsr((register_offset >> 4) + 0x800, value);
+    else
+        WRITEMEM32(apic_base_address + register_offset, value);
 }
 
+uint32_t lapic_id()
+{
+    uint32_t id = read_apic_register(APIC_ID_REGISTER_OFFSET);
+    return apicInX2Mode ? id : id >> 24;
+}
 
+bool lapic_is_x2()
+{ 
+    return apicInX2Mode; 
+}


### PR DESCRIPTION
X2APIC is detected and initialized if supported, otherwise code falls back to existing xAPIC. Also added `lapic_id()` and `lapic_is_x2()` convenience functions.

mem/util.h just contains some macros to simplify reading/writing directly to memory, hopefully makes things more readable!
Let me know what you think.

This would address #82 