### PR TITLE
86 rsdt mapping bug

### DIFF
--- a/src/include/kernel/x86_64/vm.h
+++ b/src/include/kernel/x86_64/vm.h
@@ -31,4 +31,5 @@ void initialize_vm();
 void clean_new_table(uint64_t *);
 
 void invalidate_page_table(uint64_t *);
+uint64_t ensure_address_in_higher_half( uint64_t );
 #endif

--- a/src/kernel/arch/x86_64/cpu/acpi.c
+++ b/src/kernel/arch/x86_64/cpu/acpi.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <numbers.h>
 #include <vmm.h>
+#include <kheap.h>
 
 RSDT* rsdt_root = NULL;
 unsigned int rsdtTablesTotal = 0;
@@ -15,16 +16,27 @@ unsigned int rsdtTablesTotal = 0;
 void parse_RSDT(RSDPDescriptor *descriptor){
     printf("Parse RSDP Descriptor\n");
     printf("descriptor Address: 0x%x\n", descriptor->RsdtAddress);
-    map_phys_to_virt_addr(descriptor->RsdtAddress, ensure_address_in_higher_half(descriptor->RsdtAddress), 0);
+    map_phys_to_virt_addr((void *) descriptor->RsdtAddress, (void *) ensure_address_in_higher_half(descriptor->RsdtAddress), 0);
     rsdt_root = (RSDT *) ensure_address_in_higher_half((uint64_t) descriptor->RsdtAddress);
     printf("RSDT_Address: %x\n", ensure_address_in_higher_half(descriptor->RsdtAddress));
     ACPISDTHeader header = rsdt_root->header;
     printf("RSDT_Signature: %.4s\n", header.Signature);
     printf("RSDT_Lenght: %d\n", header.Length);
+    // Ok we are here and we have mapped the "head of rsdt", it will stay most likely in one page, but there is no way
+    // to know the length of the whole table before mapping its header. So now we are able to check if we need to map extra pages
+    size_t required_extra_pages = (header.Length / KERNEL_PAGE_SIZE) + 1;
+    printf("RSDT_PAGES_NEEDED: %d\n", required_extra_pages);
+    if (required_extra_pages > 1) {
+        printf("Mapping extra pages");
+        for (int j = 1; j < required_extra_pages; j++) {
+            uint64_t new_physical_address = descriptor->RsdtAddress + (j * KERNEL_PAGE_SIZE);
+            map_phys_to_virt_addr(new_physical_address, ensure_address_in_higher_half(new_physical_address), 0);
+        }
+    }
     rsdtTablesTotal = (header.Length - sizeof(ACPISDTHeader)) / sizeof(uint32_t);
     printf("Total rsdt Tables: %d\n", rsdtTablesTotal);
     
-    for(int i=0; i < rsdtTablesTotal; i++){
+    for(int i=0; i < rsdtTablesTotal; i++) {
         ACPISDTHeader *tableHeader = (ACPISDTHeader *) rsdt_root->tables[i];
         printf("\tTable header %d: Signature: %.4s\n", i, tableHeader->Signature);
     }

--- a/src/kernel/arch/x86_64/cpu/acpi.c
+++ b/src/kernel/arch/x86_64/cpu/acpi.c
@@ -7,17 +7,18 @@
 #include <stddef.h>
 #include <string.h>
 #include <numbers.h>
-
+#include <vmm.h>
 
 RSDT* rsdt_root = NULL;
 unsigned int rsdtTablesTotal = 0;
 
 void parse_RSDT(RSDPDescriptor *descriptor){
     printf("Parse RSDP Descriptor\n");
-    rsdt_root = (RSDT *) descriptor->RsdtAddress;
     printf("descriptor Address: 0x%x\n", descriptor->RsdtAddress);
+    map_phys_to_virt_addr(descriptor->RsdtAddress, ensure_address_in_higher_half(descriptor->RsdtAddress), 0);
+    rsdt_root = (RSDT *) ensure_address_in_higher_half((uint64_t) descriptor->RsdtAddress);
+    printf("RSDT_Address: %x\n", ensure_address_in_higher_half(descriptor->RsdtAddress));
     ACPISDTHeader header = rsdt_root->header;
-    
     printf("RSDT_Signature: %.4s\n", header.Signature);
     printf("RSDT_Lenght: %d\n", header.Length);
     rsdtTablesTotal = (header.Length - sizeof(ACPISDTHeader)) / sizeof(uint32_t);

--- a/src/kernel/arch/x86_64/system/vm.c
+++ b/src/kernel/arch/x86_64/system/vm.c
@@ -1,6 +1,7 @@
 #include <vm.h>
 #include <video.h>
 #include <framebuffer.h>
+#include <main.h>
 
 extern uint32_t FRAMEBUFFER_MEMORY_SIZE;
 
@@ -42,4 +43,11 @@ void invalidate_page_table(uint64_t *table_address){
     	:
     	: "r"((uint64_t)table_address)
     	: "memory");
+}
+
+uint64_t ensure_address_in_higher_half( uint64_t address ) {
+    if ( address > _HIGHER_HALF_KERNEL_MEM_START ) {
+        return address;
+    }
+    return address + _HIGHER_HALF_KERNEL_MEM_START;
 }

--- a/src/kernel/mem/vmm.c
+++ b/src/kernel/mem/vmm.c
@@ -46,57 +46,58 @@ int unmap_vaddress(void *address){
 
 void *map_phys_to_virt_addr(void* physical_address, void* address, unsigned int flags){
     uint16_t pml4_e = PML4_ENTRY((uint64_t) address);
-    _printStringAndNumber("Mapping address: ", (unsigned long int) address);
-    _printStringAndNumber("PML4 Value: ", pml4_e);
-	uint64_t *pml4_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l,510l,510l));
-	if(!(pml4_table[pml4_e] & 0b1)){
-		uint64_t *new_table = pmm_alloc_frame();
-		pml4_table[pml4_e] = (uint64_t) new_table | WRITE_BIT | PRESENT_BIT;
-		clean_new_table(new_table);
-	}
-#if VERBOSE_OUTPUT == 1
-	_printStringAndNumber("P4_table[pml4_e]: ", p4_table[pml4_e]);
-    _printStringAndNumber("PML4 Value: ", pml4_table[pml4_e]);
-#endif
+    printf("Mapping address: 0x%x - PML4 Entry: 0x%x\n", address, pml4_e);
+    uint64_t *pml4_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l,510l,510l));
+    // If the pml4_e item in the pml4 table is not present, we need to create a new one.
+    // Every entry in pml4 table points to a pdpr table
+    if(!(pml4_table[pml4_e] & 0b1)){
+        uint64_t *new_table = pmm_alloc_frame();
+        pml4_table[pml4_e] = (uint64_t) new_table | WRITE_BIT | PRESENT_BIT;
+        clean_new_table(new_table);
+    }
+
     uint16_t pdpr_e = PDPR_ENTRY((uint64_t) address);
-	uint64_t *pdpr_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l,510l,pml4_e));
-#if VERBOSE_OUTPUT == 1
-    _printStringAndNumber("PDPR Value: ", pdpr_e);
-    _printStringAndNumber("PDPR Table[pdpr_e]: ", pdpr_table[pdpr_e]);
-#endif
-	if(!(pdpr_table[pdpr_e] & 0b1)){
-		uint64_t *new_table = pmm_alloc_frame();
-		pdpr_table[pdpr_e] = (uint64_t) new_table | WRITE_BIT | PRESENT_BIT;
-		clean_new_table(new_table);
-	}
-	uint64_t *pd_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l,pml4_e, pdpr_e));
+    uint64_t *pdpr_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l,510l, (uint64_t) pml4_e));
+
+    // If the pdpr_e item in the pdpr table is not present, we need to create a new one.
+    // Every entry in pdpr table points to a pdpr table
+    if(!(pdpr_table[pdpr_e] & 0b1)){
+        uint64_t *new_table = pmm_alloc_frame();
+        pdpr_table[pdpr_e] = (uint64_t) new_table | WRITE_BIT | PRESENT_BIT;
+        clean_new_table(new_table);
+    }
+
+    uint64_t *pd_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l,510l, (uint64_t) pml4_e, (uint64_t)  pdpr_e));
     uint16_t pd_e = PD_ENTRY((uint64_t) address);
-	if(!(pd_table[pd_e] & 0b01)){
-		uint64_t *new_table = pmm_alloc_frame();
-		#if SMALL_PAGES == 1
-		pd_table[pd_e] = (uint64_t) new_table | flags | WRITE_BIT | PRESENT_BIT;
-		#elif SMALL_PAGES == 0
-		pd_table[pd_e] = (uint64_t) physical_address | flags | WRITE_BIT | PRESENT_BIT | HUGEPAGE_BIT;
-		clean_new_table(new_table);
-		#endif
-	}
 
-    #if SMALL_PAGES == 1
-	uint64_t *pt_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l, pml4_e, pdpr_e, pd_e));
+    // If the pd_e item in the pd table is not present, we need to create a new one.
+    // Every entry in pdpr table points to a page table if using 4k pages, or to a 2mb memory area if using 2mb pages
+    if(!(pd_table[pd_e] & 0b01)){
+        uint64_t *new_table = pmm_alloc_frame();
+#if SMALL_PAGES == 1
+        pd_table[pd_e] = (uint64_t) new_table | WRITE_BIT | PRESENT_BIT;
+        clean_new_table(new_table);
+#elif SMALL_PAGES == 0
+        pd_table[pd_e] = (uint64_t) physical_address | flags | WRITE_BIT | PRESENT_BIT | HUGEPAGE_BIT;
+#endif
+    }
+
+#if SMALL_PAGES == 1
+    uint64_t *pt_table = (uint64_t *) (SIGN_EXTENSION | ENTRIES_TO_ADDRESS(510l, (uint64_t) pml4_e, (uint64_t) pdpr_e, (uint64_t) pd_e));
     uint16_t pt_e = PT_ENTRY((uint64_t) address);
-	if(!(pt_table[pt_e] & 0b1)) {
-		uint64_t *new_table = pmm_alloc_frame();
-		pt_table[pt_e] = (uint64_t) physical_address | WRITE_BIT | PRESENT_BIT;
-	}
-	#endif
+    // This case apply only for 4kb pages, if the pt_e entry is not present in the page table we need to allocate a new 4k page
+    // Every entry in the page table is a 4kb page of physical memory
+    if(!(pt_table[pt_e] & 0b1)) {
+    uint64_t *new_table = pmm_alloc_frame();
+        pt_table[pt_e] = (uint64_t) physical_address | WRITE_BIT | PRESENT_BIT;
+    }
+#endif
 
-
-	return address;
+    return address;
 }
 
 void *map_vaddress(void *virtual_address, unsigned int flags){
     void *new_addr = pmm_alloc_frame();
     return map_phys_to_virt_addr(new_addr, virtual_address, flags);
 }
-
 

--- a/src/kernel/mem/vmm.c
+++ b/src/kernel/mem/vmm.c
@@ -89,7 +89,7 @@ void *map_phys_to_virt_addr(void* physical_address, void* address, unsigned int 
     // Every entry in the page table is a 4kb page of physical memory
     if(!(pt_table[pt_e] & 0b1)) {
     uint64_t *new_table = pmm_alloc_frame();
-        pt_table[pt_e] = (uint64_t) physical_address | WRITE_BIT | PRESENT_BIT;
+        pt_table[pt_e] = (uint64_t) physical_address | flags | WRITE_BIT | PRESENT_BIT;
     }
 #endif
 


### PR DESCRIPTION
This fix a problem that was in map_phys_to_virt function. 

I was shifting uint16_t to right of more than 16 position, and it caused odd behaviour.

Btw the map_phys_to_virt need to be redesigned because the current implementation has some flaw, i will create a specific issue to keep track of that (when creating new page tables/directories it assume that the address returned for the table is already mapped). 