### PR TITLE
Task updates

### DIFF
--- a/src/include/kernel/scheduling/scheduler.h
+++ b/src/include/kernel/scheduling/scheduler.h
@@ -13,6 +13,7 @@ extern uint16_t scheduler_ticks;
 extern thread_t* current_executing_thread;
 extern thread_t* idle_thread;
 extern task_t* current_executing_task;
+extern task_t* root_task;
 
 void init_scheduler();
 cpu_status_t* schedule(cpu_status_t* cur_status);

--- a/src/include/kernel/scheduling/scheduler.h
+++ b/src/include/kernel/scheduling/scheduler.h
@@ -16,8 +16,12 @@ extern task_t* current_executing_task;
 
 void init_scheduler();
 cpu_status_t* schedule(cpu_status_t* cur_status);
+
 void scheduler_add_thread(thread_t* thread);
+void scheduler_add_task(task_t* task);
+
 thread_t* scheduler_get_next_thread();
+
 size_t scheduler_get_queue_size();
 void scheduler_delete_thread(size_t tid);
 void scheduler_yield();

--- a/src/include/kernel/scheduling/task.h
+++ b/src/include/kernel/scheduling/task.h
@@ -21,7 +21,6 @@ struct task_t {
 extern size_t next_task_id;
 
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args);
-void task_add_thread(thread_t* thread);
 task_t* get_task(size_t task_id);
 
 bool add_thread_to_task_by_id(size_t task_id, thread_t* thread);

--- a/src/include/kernel/scheduling/task.h
+++ b/src/include/kernel/scheduling/task.h
@@ -22,7 +22,7 @@ extern size_t next_task_id;
 
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args);
 void task_add_thread(thread_t* thread);
+task_t* get_task(size_t task_id);
 
-
-bool add_thread_to_task(thread_t* thread);
+bool add_thread_to_task(size_t task_id, thread_t* thread);
 #endif

--- a/src/include/kernel/scheduling/task.h
+++ b/src/include/kernel/scheduling/task.h
@@ -24,5 +24,7 @@ task_t* create_task(char *name, void (*_entry_point)(void *), void *args);
 void task_add_thread(thread_t* thread);
 task_t* get_task(size_t task_id);
 
-bool add_thread_to_task(size_t task_id, thread_t* thread);
+bool add_thread_to_task_by_id(size_t task_id, thread_t* thread);
+bool add_thread_to_task(task_t* task, thread_t* thread);
+void print_thread_list(size_t task_id);
 #endif

--- a/src/include/kernel/scheduling/task.h
+++ b/src/include/kernel/scheduling/task.h
@@ -2,6 +2,7 @@
 #define _TASK_H
 
 #include <stddef.h>
+#include <stdbool.h>
 #include <thread.h>
 
 #define TASK_NAME_MAX_LEN 32
@@ -20,4 +21,8 @@ struct task_t {
 extern size_t next_task_id;
 
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args);
+void task_add_thread(thread_t* thread);
+
+
+bool add_thread_to_task(thread_t* thread);
 #endif

--- a/src/include/kernel/scheduling/task.h
+++ b/src/include/kernel/scheduling/task.h
@@ -17,5 +17,7 @@ struct task_t {
     task_t* next;
 };
 
+extern size_t next_task_id;
+
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args);
 #endif

--- a/src/include/kernel/scheduling/thread.h
+++ b/src/include/kernel/scheduling/thread.h
@@ -33,6 +33,7 @@ struct thread_t {
     cpu_status_t *execution_frame;
     size_t wakeup_time;
     thread_t* next;
+    thread_t* scheduler_next;
 };
 
 

--- a/src/include/kernel/scheduling/thread.h
+++ b/src/include/kernel/scheduling/thread.h
@@ -33,8 +33,8 @@ struct thread_t {
     size_t ticks;
     cpu_status_t *execution_frame;
     size_t wakeup_time;
+    thread_t* next_sibling;
     thread_t* next;
-    thread_t* scheduler_next;
 };
 
 

--- a/src/include/kernel/scheduling/thread.h
+++ b/src/include/kernel/scheduling/thread.h
@@ -1,7 +1,6 @@
 #ifndef _THREAD_H_
 #define _THREAD_H_
 
-#include <task.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <cpu.h>
@@ -23,11 +22,13 @@ typedef enum {
 
 typedef struct thread_t thread_t;
 
+#include <task.h> 
+
 struct thread_t {
     uint16_t tid;
     char thread_name[THREAD_NAME_MAX_LEN];
     uintptr_t stack;
-    struct task_t* parent;
+    struct task_t* parent_task;
     thread_status status;
     size_t ticks;
     cpu_status_t *execution_frame;
@@ -39,7 +40,8 @@ struct thread_t {
 
 extern size_t next_thread_id;
 
-thread_t* create_thread(char*, void (*)(void *), void*);
+
+thread_t* create_thread(char* thread_name, void (*_entry_point)(void *) , void* arg, struct task_t* parent_task);
 void thread_execution_wrapper( void (*)(void *), void*);
 void thread_suicide_trap();
 void thread_sleep(size_t millis);

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -200,9 +200,10 @@ void kernel_start(unsigned long addr, unsigned long magic){
     char c = 'c';
     char d = 'd';
     idle_thread = create_thread("idle", noop,  &a, NULL);
-    create_task("eldi", noop2, &b);
-    create_task("ledi", noop2, &c);
+    task_t* eldi_task = create_task("eldi", noop2, &b);
+    create_thread("ledi", noop2, &c, eldi_task);
     create_task("sleeper", noop3, &d);
+    print_thread_list(eldi_task->task_id);
     //execute_runtime_tests();
     //test_get_task();
     start_apic_timer(kernel_settings.apic_timer.timer_ticks_base, APIC_TIMER_SET_PERIODIC, kernel_settings.apic_timer.timer_divisor);

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -204,6 +204,7 @@ void kernel_start(unsigned long addr, unsigned long magic){
     create_task("ledi", noop2, &c);
     create_task("sleeper", noop3, &d);
     //execute_runtime_tests();
+    //test_get_task();
     start_apic_timer(kernel_settings.apic_timer.timer_ticks_base, APIC_TIMER_SET_PERIODIC, kernel_settings.apic_timer.timer_divisor);
     while(1);
 }

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -199,7 +199,7 @@ void kernel_start(unsigned long addr, unsigned long magic){
     char b = 'b';
     char c = 'c';
     char d = 'd';
-    idle_thread = create_thread("idle", noop,  &a);
+    idle_thread = create_thread("idle", noop,  &a, NULL);
     create_task("eldi", noop2, &b);
     create_task("ledi", noop2, &c);
     create_task("sleeper", noop3, &d);

--- a/src/kernel/scheduling/scheduler.c
+++ b/src/kernel/scheduling/scheduler.c
@@ -140,11 +140,11 @@ cpu_status_t* schedule(cpu_status_t* cur_status) {
 }*/
 
 void scheduler_add_task(task_t* task) {
-    task->next = root_task;
-    root_task = task;
     if (root_task == NULL) {
         loglinef(Verbose, "First task being added: %s", task->task_name);
     }
+    task->next = root_task;
+    root_task = task;
 }
 
 void scheduler_add_thread(thread_t* thread) {

--- a/src/kernel/scheduling/scheduler.c
+++ b/src/kernel/scheduling/scheduler.c
@@ -144,7 +144,6 @@ void scheduler_add_task(task_t* task) {
     root_task = task;
     if (root_task == NULL) {
         loglinef(Verbose, "First task being added: %s", task->task_name);
-        root_task = task;
     }
 }
 

--- a/src/kernel/scheduling/scheduler.c
+++ b/src/kernel/scheduling/scheduler.c
@@ -8,7 +8,7 @@
 
 uint16_t scheduler_ticks;
 size_t next_thread_id;
-size_t next_thread_index;
+size_t next_task_id;
 
 thread_t* thread_list;
 thread_t* current_executing_thread;
@@ -19,7 +19,7 @@ size_t thread_list_size;
 
 void init_scheduler() {
     scheduler_ticks = 0;
-    next_thread_index = 0; 
+    next_task_id = 0;
     next_thread_id = 0;
     current_executing_thread = NULL;
     thread_list = NULL;
@@ -138,6 +138,13 @@ cpu_status_t* schedule(cpu_status_t* cur_status) {
    }
    return cur_status;
 }*/
+
+void scheduler_add_task(task_t* task) {
+    if (root_task == NULL) {
+        loglinef(Verbose, "First task being added: %s", task->task_name);
+        root_task = task;
+    }
+}
 
 void scheduler_add_thread(thread_t* thread) {
     thread->next = thread_list;    

--- a/src/kernel/scheduling/scheduler.c
+++ b/src/kernel/scheduling/scheduler.c
@@ -140,6 +140,8 @@ cpu_status_t* schedule(cpu_status_t* cur_status) {
 }*/
 
 void scheduler_add_task(task_t* task) {
+    task->next = root_task;
+    root_task = task;
     if (root_task == NULL) {
         loglinef(Verbose, "First task being added: %s", task->task_name);
         root_task = task;

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -17,13 +17,23 @@ task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
     return new_task;
 }
 
-bool add_thread_to_task(size_t task_id, thread_t* thread) {
+bool add_thread_to_task_by_id(size_t task_id, thread_t* thread) {
     task_t* task = get_task(task_id);
     if (task_id > next_task_id || task == NULL) {
         return false;
     }
-    thread->next = task->next_sibling;
-    task->next_sibling = thread;
+    thread->next = task->threads;
+    thread->next_sibling = thread;
+    return true;
+}
+
+bool add_thread_to_task(task_t* task, thread_t* thread) {
+    if (task == NULL) {
+        return false;
+    }
+    thread->next = task->threads;
+    thread->next_sibling = thread;
+    return true;
 }
 
 task_t* get_task(size_t task_id) {
@@ -39,4 +49,15 @@ task_t* get_task(size_t task_id) {
         cur_task = cur_task->next;
     }
     return NULL;
+}
+
+void print_thread_list(size_t task_id) {
+    task_t* task = get_task(task_id);
+    if (task != NULL) {
+        thread_t* thread = task->threads;
+        while(thread != NULL) {
+            loglinef(Verbose, "\tThread; %d - %s", thread->tid, thread->thread_name);
+            thread = thread->next;
+        }
+    }
 }

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -7,9 +7,11 @@
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
     task_t* new_task = (task_t*) kmalloc(sizeof(task_t));
     strcpy(new_task->task_name, name);
-    loglinef(Verbose, "Task created with name: %s", new_task->task_name);
     thread_t* thread = create_thread(name, _entry_point, args);
     new_task->threads = thread;
     new_task->parent = NULL;
+    new_task->task_id = next_task_id++;
+    loglinef(Verbose, "Task created with name: %s - Task id: %d", new_task->task_name, new_task->task_id);
+    scheduler_add_task(new_task);
     return new_task;
 }

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -19,16 +19,17 @@ task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
 
 bool add_thread_to_task_by_id(size_t task_id, thread_t* thread) {
     task_t* task = get_task(task_id);
-    if (task_id > next_task_id || task == NULL) {
+    if (task == NULL) {
         return false;
     }
+    thread->parent_task = task;
     thread->next = task->threads;
     thread->next_sibling = thread;
     return true;
 }
 
 bool add_thread_to_task(task_t* task, thread_t* thread) {
-    if (task == NULL) {
+    if (task == NULL || thread == NULL) {
         return false;
     }
     thread->next = task->threads;

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -7,11 +7,15 @@
 task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
     task_t* new_task = (task_t*) kmalloc(sizeof(task_t));
     strcpy(new_task->task_name, name);
-    thread_t* thread = create_thread(name, _entry_point, args);
-    new_task->threads = thread;
     new_task->parent = NULL;
     new_task->task_id = next_task_id++;
     loglinef(Verbose, "Task created with name: %s - Task id: %d", new_task->task_name, new_task->task_id);
+    thread_t* thread = create_thread(name, _entry_point, args, new_task);
+    new_task->threads = thread;
     scheduler_add_task(new_task);
     return new_task;
+}
+
+bool add_thread_to_task(thread_t* thread) {
+
 }

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -1,4 +1,5 @@
 #include <task.h>
+#include <scheduler.h>
 #include <kheap.h>
 #include <string.h>
 #include <logging.h>
@@ -16,6 +17,26 @@ task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
     return new_task;
 }
 
-bool add_thread_to_task(thread_t* thread) {
+bool add_thread_to_task(size_t task_id, thread_t* thread) {
+    task_t* task = get_task(task_id);
+    if (task_id > next_task_id || task == NULL) {
+        return false;
+    }
+    thread->next = task->next_sibling;
+    task->next_sibling = thread;
+}
 
+task_t* get_task(size_t task_id) {
+    if (task_id > next_task_id) {
+        return NULL;
+    }
+    task_t* cur_task = root_task;
+    while ( cur_task != NULL ) {
+        loglinef(Verbose, "Searching task: %d", cur_task->task_id);
+        if ( cur_task->task_id == task_id ) {
+            return cur_task;
+        }
+        cur_task = cur_task->next;
+    }
+    return NULL;
 }

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -7,10 +7,10 @@
 #include <logging.h>
 #include <kernel.h>
 
-thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* arg) {
+thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* arg, task_t* parent_task) {
     thread_t *new_thread = kmalloc(sizeof(thread_t));
     new_thread->tid = next_thread_id++;
-    new_thread->parent = NULL;
+    new_thread->parent_task = NULL;
     new_thread->status = NEW;
     new_thread->wakeup_time = 0;
     strcpy(new_thread->thread_name, thread_name);
@@ -35,6 +35,10 @@ thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* a
     // The stack grow backward, so the pointer will be the end of the stack
     new_thread->stack = stack_pointer + THREAD_DEFAULT_STACK_SIZE;
     new_thread->execution_frame->rsp = (uint64_t) new_thread->stack;
+
+    if (parent_task != NULL) {
+        new_thread->parent_task = parent_task;
+    }
     
     scheduler_add_thread(new_thread);
     return new_thread;

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -37,7 +37,6 @@ thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* a
     new_thread->execution_frame->rsp = (uint64_t) new_thread->stack;
 
     if (parent_task != NULL) {
-        new_thread->parent_task = parent_task;
         add_thread_to_task(parent_task, new_thread);
     }
     

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -38,6 +38,7 @@ thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* a
 
     if (parent_task != NULL) {
         new_thread->parent_task = parent_task;
+        add_thread_to_task(parent_task, new_thread);
     }
     
     scheduler_add_thread(new_thread);

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -15,7 +15,7 @@ thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* a
     new_thread->wakeup_time = 0;
     strcpy(new_thread->thread_name, thread_name);
     new_thread->next = NULL;
-    new_thread->scheduler_next = NULL;
+    new_thread->next_sibling = NULL;
     new_thread->ticks = 0;
     loglinef(Verbose, "Creating thread with arg: %c - arg: %x - name: %s", (char) *((char*) arg), arg, thread_name);
 

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -15,6 +15,7 @@ thread_t* create_thread(char* thread_name, void (*_entry_point)(void *), void* a
     new_thread->wakeup_time = 0;
     strcpy(new_thread->thread_name, thread_name);
     new_thread->next = NULL;
+    new_thread->scheduler_next = NULL;
     new_thread->ticks = 0;
     loglinef(Verbose, "Creating thread with arg: %c - arg: %x - name: %s", (char) *((char*) arg), arg, thread_name);
 


### PR DESCRIPTION
Add new field for task_threads.

There will be two pointers: next that are used by the scheduler to pick the next thread to execute, and next_sibling will contain the next thread within the same task. 

Made functions to handle add_thread to task, get_task

Add parent reference to create_thread, if not null it will be added to the specified task.