### PR TITLE
173 vmm per task

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -28,6 +28,6 @@ Below the flags that are currently implemented to control the build/execution of
 * `build`: Just build the os, and create the iso in `$BUILD_FOLDER`
 * `run`:  It run the os using qemu
 * `clean`: To delete all build files
-* `debug`: To start the OS with the DEBUG flug active, it will print all messages on stdout, logging in _Verbose_ mode
+* `debug`: To start the OS with the DEBUG flag active, it will print all messages on stdout, logging in _Verbose_ mode
 * `gdb`: To start the OS with remote debugging mode enabled, to start the OS you need to connect using gdb and control execution from there.
 * `tests`: To run some _kind of_ unit tests.

--- a/src/include/kernel/mem/vmm.h
+++ b/src/include/kernel/mem/vmm.h
@@ -53,18 +53,18 @@ typedef struct VmmInfo {
     uintptr_t vmmDataStart; /**< The start of the VMM reserved area for it's own data structures */
     uintptr_t vmmSpaceStart; /**< The start of the VMM space, where all allocation will be placed */
 
-    size_t start_of_vmm_space;
+    size_t start_of_vmm_space; /**< The starting addres ofthe vmm space */
 
     struct VmmStatus {
-        size_t vmm_items_per_page;
-        size_t vmm_cur_index;
+        size_t vmm_items_per_page; /**< Number of page items contained in one page */
+        size_t vmm_cur_index; /**< Current position inside the array */
 
-        size_t next_available_address;
+        size_t next_available_address; /**< The next available address */
 
-        uint64_t end_of_vmm_data;
+        uint64_t end_of_vmm_data; /**< We should never reach here, where the vmm_data finish */
 
-        VmmContainer *vmm_container_root;
-        VmmContainer *vmm_cur_container;
+        VmmContainer *vmm_container_root; /**< Root node of the vmmContainer */
+        VmmContainer *vmm_cur_container; /**< Current pointer */
     } status;
 } VmmInfo;
 

--- a/src/kernel/mem/vmm.c
+++ b/src/kernel/mem/vmm.c
@@ -82,9 +82,8 @@ void vmm_init(vmm_level_t vmm_level, VmmInfo *vmm_info) {
 
     // Mapping the phyiscal address for the vmm structures
     map_phys_to_virt_addr(vmm_root_phys, vmm_info->status.vmm_container_root, VMM_FLAGS_PRESENT | VMM_FLAGS_WRITE_ENABLE);
-    //vmm_container_root->next = NULL;
+
     vmm_info->status.vmm_container_root->next = NULL;
-    //vmm_cur_container = vmm_container_root;
     vmm_info->status.vmm_cur_container = vmm_info->status.vmm_container_root;
 }
 

--- a/src/kernel/mem/vmm.c
+++ b/src/kernel/mem/vmm.c
@@ -38,7 +38,7 @@ void vmm_init(vmm_level_t vmm_level, VmmInfo *vmm_info) {
     if (vmm_info == NULL) {
         vmm_info = &vmm_kernel;
     }
-    //vmm_info.higherHalfDirectMapBase is where we will the Direct Mapping of physical memory will start.
+    //higherHalfDirectMapBase is where we will the Direct Mapping of physical memory will start.
     higherHalfDirectMapBase = ((uint64_t) HIGHER_HALF_ADDRESS_OFFSET + VM_KERNEL_MEMORY_PADDING);
 
     vmm_info->vmmDataStart = align_value_to_page(higherHalfDirectMapBase + memory_size_in_bytes + VM_KERNEL_MEMORY_PADDING);
@@ -57,7 +57,7 @@ void vmm_init(vmm_level_t vmm_level, VmmInfo *vmm_info) {
     } else if (vmm_level == VMM_LEVEL_USER) {
         loglinef(Verbose, "(%s): User level initialization", __FUNCTION__);
         vmm_info->vmmSpaceStart = 0x0l + VM_KERNEL_MEMORY_PADDING;
-        start_of_vmm_space = 0x0l + VM_KERNEL_MEMORY_PADDING;
+        //start_of_vmm_space = 0x0l + VM_KERNEL_MEMORY_PADDING;
         vmm_info->start_of_vmm_space = 0x0l + VM_KERNEL_MEMORY_PADDING;
         loglinef(Fatal, "(%s): Not implemented yet", __FUNCTION__);
     } else {

--- a/src/kernel/mem/vmm.c
+++ b/src/kernel/mem/vmm.c
@@ -59,7 +59,7 @@ void vmm_init(vmm_level_t vmm_level, VmmInfo *vmm_info) {
         vmm_info->vmmSpaceStart = 0x0l + VM_KERNEL_MEMORY_PADDING;
         //start_of_vmm_space = 0x0l + VM_KERNEL_MEMORY_PADDING;
         vmm_info->start_of_vmm_space = 0x0l + VM_KERNEL_MEMORY_PADDING;
-        loglinef(Fatal, "(%s): Not implemented yet", __FUNCTION__);
+        //loglinef(Fatal, "(%s): Not implemented yet", __FUNCTION__);
     } else {
         loglinef(Fatal, "(%s): Error: unsupported vmm privilege level", __FUNCTION__);
     }
@@ -67,9 +67,9 @@ void vmm_init(vmm_level_t vmm_level, VmmInfo *vmm_info) {
     vmm_info->status.next_available_address = vmm_info->start_of_vmm_space;
     vmm_info->status.vmm_items_per_page = (PAGE_SIZE_IN_BYTES / sizeof(VmmItem)) - 1;
     vmm_info->status.vmm_cur_index = 0;
-    loglinef(Verbose, "(vmm_init): vmm_container_root starts at: 0x%x - %d", vmm_info->status.vmm_container_root, is_address_aligned(vmm_info->vmmDataStart, PAGE_SIZE_IN_BYTES));
-    loglinef(Verbose, "(vmm_init): vmmDataStart  starts at: 0x%x - %x (end_of_vmm_data)", vmm_info->vmmDataStart, vmm_info->status.end_of_vmm_data);
-    loglinef(Verbose, "(vmm_init): higherHalfDirectMapBase: %x, is_aligned: %d", (uint64_t) higherHalfDirectMapBase, is_address_aligned(higherHalfDirectMapBase, PAGE_SIZE_IN_BYTES));
+    loglinef(Verbose, "(%s): vmm_container_root starts at: 0x%x - %d", __FUNCTION__, vmm_info->status.vmm_container_root, is_address_aligned(vmm_info->vmmDataStart, PAGE_SIZE_IN_BYTES));
+    loglinef(Verbose, "(%s): vmmDataStart  starts at: 0x%x - %x (end_of_vmm_data)", __FUNCTION__, vmm_info->vmmDataStart, vmm_info->status.end_of_vmm_data);
+    loglinef(Verbose, "(%s): higherHalfDirectMapBase: %x, is_aligned: %d", __FUNCTION__, (uint64_t) higherHalfDirectMapBase, is_address_aligned(higherHalfDirectMapBase, PAGE_SIZE_IN_BYTES));
     loglinef(Verbose, "(%s): vmmSpaceStart: %x - start_of_vmm_space: (%x)", __FUNCTION__,  (uint64_t) vmm_info->vmmSpaceStart, vmm_info->start_of_vmm_space);
     loglinef(Verbose, "(%s): sizeof VmmContainer: 0x%x", __FUNCTION__, sizeof(VmmContainer));
 

--- a/src/kernel/scheduling/task.c
+++ b/src/kernel/scheduling/task.c
@@ -25,6 +25,7 @@ task_t* create_task(char *name, void (*_entry_point)(void *), void *args) {
         new_task->threads = thread;
     }
     prepare_virtual_memory_environment(new_task);
+    vmm_init(VMM_LEVEL_USER, &(new_task->vmm_data));
     scheduler_add_task(new_task);
     //load_cr3(new_task->vm_root_page_table);
     //re-enable interrupts

--- a/src/kernel/scheduling/thread.c
+++ b/src/kernel/scheduling/thread.c
@@ -142,6 +142,9 @@ void noop3(char *c) {
     uint64_t *test_addr = (uint64_t  *) vmm_alloc(2097253, 0, NULL);
     test_addr[0] = 5;
     loglinef(Verbose, "(noop3): test_addr[0] = %d", test_addr[0]);
+    task_t *current_task = current_executing_thread->parent_task;
+    uint64_t *tmp_var = vmm_alloc(0x1000, VMM_FLAGS_PRESENT | VMM_FLAGS_WRITE_ENABLE, &(current_task->vmm_data));
+    loglinef(Verbose, "(%s) Tmp var address returned by vmm_alloc: 0x%x", __FUNCTION__, tmp_var);
 }
 
 char *get_thread_status(thread_t *thread) {


### PR DESCRIPTION
That should be everything?

I added a vmm_alloc test using one of the tasks vmm. 

It returns the correct address: 

```
[VERBOSE] (vmm_alloc): Testing vm_parse_flags: 0x3
[VERBOSE] (vmm_alloc) newly allocated item base: 200000, next available address: 400000
[VERBOSE] (noop3) Tmp var address returned by vmm_alloc: 0x200000
``` 

I think this mean that it is at least working kind of... 